### PR TITLE
Add specs for emoji reactions

### DIFF
--- a/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
@@ -26,10 +26,6 @@ describe Api::V1::Statuses::ReactionsController do
           expect(response).to have_http_status(200)
         end
 
-        it 'updates the reactions count' do
-          expect(status.status_reactions.count).to eq 1
-        end
-
         it 'updates the reacted attribute' do
           expect(user.account.reacted?(status, '👍')).to be true
         end
@@ -38,7 +34,6 @@ describe Api::V1::Statuses::ReactionsController do
           hash_body = body_as_json
 
           expect(hash_body[:id]).to eq status.id.to_s
-          expect(hash_body[:reactions_count]).to eq 1
           expect(hash_body[:reactions]).to_not be_empty
           expect(hash_body[:reactions][0][:count]).to be 1
           expect(hash_body[:reactions][0][:me]).to be true
@@ -68,10 +63,6 @@ describe Api::V1::Statuses::ReactionsController do
           expect(response).to have_http_status(200)
         end
 
-        it 'updates the reactions count' do
-          expect(status.status_reactions.count).to eq 0
-        end
-
         it 'updates the reacted attribute' do
           expect(user.account.reacted?(status, '👍')).to be false
         end
@@ -80,7 +71,6 @@ describe Api::V1::Statuses::ReactionsController do
           hash_body = body_as_json
 
           expect(hash_body[:id]).to eq status.id.to_s
-          expect(hash_body[:reactions_count]).to eq 0
           expect(hash_body[:reactions]).to be_empty
         end
       end

--- a/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
+++ b/spec/controllers/api/v1/statuses/reactions_controller_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::Statuses::ReactionsController do
+  render_views
+
+  let(:user)  { Fabricate(:user) }
+  let(:app)   { Fabricate(:application, name: 'Test app', website: 'http://testapp.com') }
+  let(:token) { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: 'write:favourites', application: app) }
+
+  context 'with an oauth token' do
+    before do
+      allow(controller).to receive(:doorkeeper_token) { token }
+    end
+
+    describe 'POST #create' do
+      let(:status) { Fabricate(:status, account: user.account) }
+
+      before do
+        post :create, params: { status_id: status.id, id: '👍' }
+      end
+
+      context 'with public status' do
+        it 'returns http success' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'updates the reactions count' do
+          expect(status.status_reactions.count).to eq 1
+        end
+
+        it 'updates the reacted attribute' do
+          expect(user.account.reacted?(status, '👍')).to be true
+        end
+
+        it 'returns json with updated attributes' do
+          hash_body = body_as_json
+
+          expect(hash_body[:id]).to eq status.id.to_s
+          expect(hash_body[:reactions_count]).to eq 1
+          expect(hash_body[:reactions]).to_not be_empty
+          expect(hash_body[:reactions][0][:count]).to be 1
+          expect(hash_body[:reactions][0][:me]).to be true
+          expect(hash_body[:reactions][0][:name]).to eq '👍'
+        end
+      end
+
+      context 'with private status of not-followed account' do
+        let(:status) { Fabricate(:status, visibility: :private) }
+
+        it 'returns http not found' do
+          expect(response).to have_http_status(404)
+        end
+      end
+    end
+
+    describe 'POST #destroy' do
+      context 'with public status' do
+        let(:status) { Fabricate(:status, account: user.account) }
+
+        before do
+          ReactService.new.call(user.account, status, '👍')
+          post :destroy, params: { status_id: status.id, id: '👍' }
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'updates the reactions count' do
+          expect(status.status_reactions.count).to eq 0
+        end
+
+        it 'updates the reacted attribute' do
+          expect(user.account.reacted?(status, '👍')).to be false
+        end
+
+        it 'returns json with updated attributes' do
+          hash_body = body_as_json
+
+          expect(hash_body[:id]).to eq status.id.to_s
+          expect(hash_body[:reactions_count]).to eq 0
+          expect(hash_body[:reactions]).to be_empty
+        end
+      end
+
+      context 'with public status when blocked by its author' do
+        let(:status) { Fabricate(:status) }
+
+        before do
+          ReactService.new.call(user.account, status, '👍')
+          status.account.block!(user.account)
+          post :destroy, params: { status_id: status.id, id: '👍' }
+        end
+
+        it 'returns http success' do
+          expect(response).to have_http_status(200)
+        end
+
+        it 'updates the reacted attribute' do
+          expect(user.account.reacted?(status, '👍')).to be false
+        end
+
+        it 'returns json with updated attributes' do
+          hash_body = body_as_json
+
+          expect(hash_body[:id]).to eq status.id.to_s
+          expect(hash_body[:reactions]).to be_empty
+        end
+      end
+
+      context 'with private status that was not reacted to' do
+        let(:status) { Fabricate(:status, visibility: :private) }
+
+        before do
+          post :destroy, params: { status_id: status.id, id: '👍' }
+        end
+
+        it 'returns http not found' do
+          expect(response).to have_http_status(404)
+        end
+      end
+    end
+  end
+end

--- a/spec/fabricators/status_reaction_fabricator.rb
+++ b/spec/fabricators/status_reaction_fabricator.rb
@@ -4,5 +4,5 @@ Fabricator(:status_reaction) do
   account
   status
   name '👍'
-  custom_emoji
+  custom_emoji nil
 end

--- a/spec/lib/activitypub/activity/emoji_react_spec.rb
+++ b/spec/lib/activitypub/activity/emoji_react_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::Activity::EmojiReact do
+  let(:sender) { Fabricate(:account) }
+  let(:recipient) { Fabricate(:account) }
+  let(:status)    { Fabricate(:status, account: recipient) }
+
+  let(:json) do
+    {
+      '@context': 'https://www.w3.org/ns/activitystreams',
+      id: 'foo',
+      type: 'EmojiReact',
+      content: '👍',
+      actor: ActivityPub::TagManager.instance.uri_for(sender),
+      object: ActivityPub::TagManager.instance.uri_for(status),
+    }.with_indifferent_access
+  end
+
+  describe '#perform' do
+    context 'with an emoji' do
+      subject { described_class.new(json, sender) }
+
+      before do
+        subject.perform
+      end
+
+      it 'creates a reaction from sender to status' do
+        expect(sender.reacted?(status, json['content'])).to be true
+      end
+    end
+
+    context 'with a custom emoji' do
+      subject { described_class.new(json, sender) }
+
+      let(:json) do
+        {
+          '@context': 'https://www.w3.org/ns/activitystreams',
+          id: 'foo',
+          type: 'EmojiReact',
+          content: +':tinking:',
+          tag: [
+            {
+              type: 'Emoji',
+              icon: {
+                url: 'http://example.com/emoji.png',
+              },
+              name: 'tinking',
+            },
+          ],
+          actor: ActivityPub::TagManager.instance.uri_for(sender),
+          object: ActivityPub::TagManager.instance.uri_for(status),
+        }.with_indifferent_access
+      end
+
+      before do
+        stub_request(:get, 'http://example.com/emoji.png').to_return(body: attachment_fixture('emojo.png'))
+        subject.perform
+      end
+
+      it 'creates a reaction from sender to status' do
+        expect(sender.reacted?(status, 'tinking', CustomEmoji.find_by(shortcode: 'tinking', domain: sender.domain))).to be true
+      end
+    end
+  end
+end

--- a/spec/lib/activitypub/activity/like_spec.rb
+++ b/spec/lib/activitypub/activity/like_spec.rb
@@ -21,11 +21,124 @@ RSpec.describe ActivityPub::Activity::Like do
     subject { described_class.new(json, sender) }
 
     before do
+      stub_request(:get, 'http://example.com/emoji.png').to_return(body: attachment_fixture('emojo.png'))
       subject.perform
     end
 
     it 'creates a favourite from sender to status' do
       expect(sender.favourited?(status)).to be true
+    end
+
+    context 'when a Misskey reaction' do
+      context 'with emoji' do
+        let(:json) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: 'foo',
+            type: 'Like',
+            _misskey_reaction: '👍',
+            actor: ActivityPub::TagManager.instance.uri_for(sender),
+            object: ActivityPub::TagManager.instance.uri_for(status),
+          }.with_indifferent_access
+        end
+
+        it 'does not create a favourite from sender to status' do
+          expect(sender.favourited?(status)).to be false
+        end
+
+        it 'creates a status reaction from sender to status' do
+          expect(sender.reacted?(status, '👍')).to be true
+        end
+      end
+
+      context 'with custom emoji' do
+        let(:json) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: 'foo',
+            type: 'Like',
+            _misskey_reaction: +':tinking:',
+            tag: [
+              {
+                type: 'Emoji',
+                icon: {
+                  url: 'http://example.com/emoji.png',
+                },
+                name: 'tinking',
+              },
+            ],
+            actor: ActivityPub::TagManager.instance.uri_for(sender),
+            object: ActivityPub::TagManager.instance.uri_for(status),
+          }.with_indifferent_access
+        end
+
+        it 'does not create a favourite from sender to status' do
+          expect(sender.favourited?(status)).to be false
+        end
+
+        it 'creates a reaction from sender to status' do
+          expect(sender.reacted?(status, 'tinking', CustomEmoji.find_by(shortcode: 'tinking', domain: sender.domain))).to be true
+        end
+      end
+    end
+  end
+
+  describe '#maybe_process_misskey_reaction' do
+    subject { described_class.new(json, sender) }
+
+    context 'when given a Misskey reaction' do
+      context 'with emoji' do
+        let(:json) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: 'foo',
+            type: 'Like',
+            _misskey_reaction: '👍',
+            actor: ActivityPub::TagManager.instance.uri_for(sender),
+            object: ActivityPub::TagManager.instance.uri_for(status),
+          }.with_indifferent_access
+        end
+
+        it 'retruns true' do
+          expect(subject.maybe_process_misskey_reaction).to be true
+        end
+      end
+
+      context 'with custom emoji' do
+        let(:json) do
+          {
+            '@context': 'https://www.w3.org/ns/activitystreams',
+            id: 'foo',
+            type: 'Like',
+            _misskey_reaction: +':tinking:',
+            tag: [
+              {
+                type: 'Emoji',
+                icon: {
+                  url: 'http://example.com/emoji.png',
+                },
+                name: 'tinking',
+              },
+            ],
+            actor: ActivityPub::TagManager.instance.uri_for(sender),
+            object: ActivityPub::TagManager.instance.uri_for(status),
+          }.with_indifferent_access
+        end
+
+        before do
+          stub_request(:get, 'http://example.com/emoji.png').to_return(body: attachment_fixture('emojo.png'))
+        end
+
+        it 'returns true' do
+          expect(subject.maybe_process_misskey_reaction).to be true
+        end
+      end
+    end
+
+    context 'when given a regular like' do
+      it 'returns false' do
+        expect(subject.maybe_process_misskey_reaction).to be false
+      end
     end
   end
 end

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -524,6 +524,47 @@ describe AccountInteractions do
     end
   end
 
+  describe '#reacted?' do
+    subject { account.reacted?(status, '👍') }
+
+    let(:status) { Fabricate(:status, account: account, status_reactions: reactions) }
+    let(:custom_emoji) { Fabricate(:custom_emoji) }
+
+    context 'when reacted' do
+      let(:reactions) { [Fabricate(:status_reaction, account: account)] }
+
+      it 'returns true' do
+        expect(subject).to be true
+      end
+
+      context 'with custom emoji' do
+        subject { account.reacted?(status, custom_emoji.shortcode, custom_emoji) }
+
+        let(:reactions) { [Fabricate(:status_reaction, account: account, name: custom_emoji.shortcode, custom_emoji: custom_emoji)] }
+
+        it 'returns true' do
+          expect(subject).to be true
+        end
+      end
+    end
+
+    context 'when not reacted' do
+      let(:reactions) { [] }
+
+      it 'returns false' do
+        expect(subject).to be false
+      end
+
+      context 'with custom emoji' do
+        subject { account.reacted?(status, custom_emoji.shortcode, custom_emoji) }
+
+        it 'returns false' do
+          expect(subject).to be false
+        end
+      end
+    end
+  end
+
   describe '#reblogged?' do
     subject { account.reblogged?(status) }
 

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Notification do
     let(:reblog)       { Fabricate(:status, reblog: status) }
     let(:favourite)    { Fabricate(:favourite, status: status) }
     let(:mention)      { Fabricate(:mention, status: status) }
+    let(:reaction)     { Fabricate(:status_reaction, status: status) }
 
     context 'when Activity is reblog' do
       let(:activity) { reblog }
@@ -29,6 +30,14 @@ RSpec.describe Notification do
 
     context 'when Activity is mention' do
       let(:activity) { mention }
+
+      it 'returns status' do
+        expect(notification.target_status).to eq status
+      end
+    end
+
+    context 'when Activity is react' do
+      let(:activity) { reaction }
 
       it 'returns status' do
         expect(notification.target_status).to eq status
@@ -55,6 +64,11 @@ RSpec.describe Notification do
     it 'returns :follow for a Follow' do
       notification = described_class.new(activity: Follow.new)
       expect(notification.type).to eq :follow
+    end
+
+    it 'returns :reaction for a Reaction' do
+      notification = described_class.new(activity: StatusReaction.new)
+      expect(notification.type).to eq :reaction
     end
   end
 
@@ -86,6 +100,7 @@ RSpec.describe Notification do
       let(:follow_request) { Fabricate(:follow_request) }
       let(:favourite) { Fabricate(:favourite) }
       let(:poll) { Fabricate(:poll) }
+      let(:reaction) { Fabricate(:status_reaction) }
 
       let(:notifications) do
         [
@@ -96,6 +111,7 @@ RSpec.describe Notification do
           Fabricate(:notification, type: :follow_request, activity: follow_request),
           Fabricate(:notification, type: :favourite, activity: favourite),
           Fabricate(:notification, type: :poll, activity: poll),
+          Fabricate(:notification, type: :reaction, activity: reaction),
         ]
       end
 
@@ -138,6 +154,12 @@ RSpec.describe Notification do
           expect(subject[6].association(:poll)).to be_loaded
           expect(subject[6].poll.association(:status)).to be_loaded
         end
+
+        it 'preloads reaction' do
+          expect(subject[7].type).to eq :reaction
+          expect(subject[7].association(:status_reaction)).to be_loaded
+          expect(subject[7].reaction.association(:status)).to be_loaded
+        end
       end
 
       context 'with a cached status' do
@@ -179,6 +201,12 @@ RSpec.describe Notification do
           expect(subject[6].type).to eq :poll
           expect(subject[6].target_status.association(:account)).to be_loaded
           expect(subject[6].target_status).to eq poll.status
+        end
+
+        it 'replaces reaction' do
+          expect(subject[7].type).to eq :reaction
+          expect(subject[7].target_status.association(:account)).to be_loaded
+          expect(subject[7].target_status).to eq reaction.status
         end
       end
     end

--- a/spec/models/status_reaction_spec.rb
+++ b/spec/models/status_reaction_spec.rb
@@ -1,3 +1,52 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+
+RSpec.describe StatusReaction do
+  let(:account) { Fabricate(:account) }
+  let(:status) { Fabricate(:status) }
+
+  describe 'validations' do
+    let(:custom_emoji) { Fabricate(:custom_emoji) }
+
+    it 'is invalid without name' do
+      expect(described_class.new(name: '', account: account, status: status)).to_not be_valid
+      expect(described_class.new(name: '', account: account, status: status, custom_emoji: custom_emoji)).to_not be_valid
+    end
+
+    it 'is valid with name' do
+      expect(described_class.new(name: '👍', account: account, status: status)).to be_valid
+      expect(described_class.new(name: custom_emoji.shortcode, account: account, status: status, custom_emoji: custom_emoji)).to be_valid
+    end
+  end
+
+  describe 'before validations' do
+    let(:custom_emoji) { Fabricate(:custom_emoji) }
+    let(:remote_custom_emoji) { Fabricate(:custom_emoji, domain: 'example.com') }
+    let(:disabled_custom_emoji) { Fabricate(:custom_emoji, disabled: true) }
+
+    context 'when given a local custom emoji' do
+      it 'sets custom_emoji to local custom emoji' do
+        expect(described_class.create(name: custom_emoji.shortcode, account: account, status: status, custom_emoji: custom_emoji).custom_emoji).to eq custom_emoji
+      end
+    end
+
+    context 'when given a remote custom emoji' do
+      it 'sets custom_emoji to remote custom emoji' do
+        expect(described_class.create(name: remote_custom_emoji.shortcode, account: account, status: status, custom_emoji: remote_custom_emoji).custom_emoji).to eq remote_custom_emoji
+      end
+    end
+
+    context 'when not given a custom emoji' do
+      it 'sets custom_emoji to nil' do
+        expect(described_class.create(name: custom_emoji.shortcode, account: account, status: status, custom_emoji: nil).custom_emoji).to be_nil
+      end
+    end
+
+    context 'when given a disabled custom emoji' do
+      it 'sets custom_emoji to nil' do
+        expect(described_class.create(name: disabled_custom_emoji.shortcode, account: account, status: status, custom_emoji: disabled_custom_emoji).custom_emoji).to be_nil
+      end
+    end
+  end
+end

--- a/spec/policies/status_policy_spec.rb
+++ b/spec/policies/status_policy_spec.rb
@@ -151,6 +151,24 @@ RSpec.describe StatusPolicy, type: :model do
     end
   end
 
+  context 'with the permission of react?' do
+    permissions :react? do
+      it 'grants access when viewer is not blocked' do
+        follow         = Fabricate(:follow)
+        status.account = follow.target_account
+
+        expect(subject).to permit(follow.account, status)
+      end
+
+      it 'denies when viewer is blocked' do
+        block          = Fabricate(:block)
+        status.account = block.target_account
+
+        expect(subject).to_not permit(block.account, status)
+      end
+    end
+  end
+
   context 'with the permission of update?' do
     permissions :update? do
       it 'grants access if owner' do

--- a/spec/services/react_service_spec.rb
+++ b/spec/services/react_service_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReactService, type: :service do
+  subject { described_class.new }
+
+  let(:sender) { Fabricate(:account, username: 'alice') }
+
+  describe 'local' do
+    let(:bob)    { Fabricate(:account) }
+    let(:status) { Fabricate(:status, account: bob) }
+
+    before do
+      subject.call(sender, status, '👍')
+    end
+
+    it 'creates a reaction' do
+      expect(status.reactions.first).to_not be_nil
+    end
+  end
+
+  describe 'remote ActivityPub' do
+    let(:bob)    { Fabricate(:account, protocol: :activitypub, username: 'bob', domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+    let(:status) { Fabricate(:status, account: bob) }
+
+    before do
+      stub_request(:post, 'http://example.com/inbox').to_return(status: 200, body: '', headers: {})
+      subject.call(sender, status, '👍')
+    end
+
+    it 'creates a reaction' do
+      expect(status.reactions.first).to_not be_nil
+    end
+
+    it 'sends a react activity' do
+      expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
+    end
+  end
+end

--- a/spec/services/unreact_service_spec.rb
+++ b/spec/services/unreact_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe UnreactService, type: :service do
+  subject { described_class.new }
+
+  let(:sender) { Fabricate(:account, username: 'alice') }
+
+  describe 'local' do
+    let(:bob)    { Fabricate(:account) }
+    let(:status) { Fabricate(:status, account: bob) }
+
+    before do
+      sender.status_reactions.find_or_create_by!(status: status, name: '👍')
+      subject.call(sender, status, '👍')
+    end
+
+    it 'removes a reaction' do
+      expect(status.reactions.first).to be_nil
+    end
+  end
+
+  describe 'remote ActivityPub' do
+    let(:bob)    { Fabricate(:account, protocol: :activitypub, username: 'bob', domain: 'example.com', inbox_url: 'http://example.com/inbox') }
+    let(:status) { Fabricate(:status, account: bob) }
+
+    before do
+      sender.status_reactions.find_or_create_by!(status: status, name: '👍')
+      stub_request(:post, 'http://example.com/inbox').to_return(status: 200, body: '', headers: {})
+      subject.call(sender, status, '👍')
+    end
+
+    it 'removes a reaction' do
+      expect(status.reactions.first).to be_nil
+    end
+
+    it 'sends an undo activity' do
+      expect(a_request(:post, 'http://example.com/inbox')).to have_been_made.once
+    end
+  end
+end

--- a/spec/validators/status_reaction_validator_spec.rb
+++ b/spec/validators/status_reaction_validator_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe StatusReactionValidator do
+  let(:status) { Fabricate(:status) }
+  let(:account) { Fabricate(:account) }
+  let(:remote_account) { Fabricate(:account, domain: 'example.com') }
+
+  describe '#validate' do
+    it 'adds error when not a valid unicode emoji' do
+      reaction = status.reactions.build(name: 'F', account: account)
+      subject.validate(reaction)
+      expect(reaction.errors).to_not be_empty
+    end
+
+    it 'does not add error when non-unicode emoji is a custom emoji' do
+      custom_emoji = Fabricate(:custom_emoji)
+      reaction = status.reactions.build(name: custom_emoji.shortcode, custom_emoji: custom_emoji, account: account)
+      subject.validate(reaction)
+      expect(reaction.errors).to be_empty
+    end
+
+    it 'adds error when local account already reacted' do
+      status.reactions.create!(name: '👍', account: account)
+
+      reaction = status.reactions.build(name: '😘', account: account)
+      subject.validate(reaction)
+      expect(reaction.errors).to_not be_empty
+    end
+
+    it 'does not add error when remote account already reacted' do
+      status.reactions.create!(name: '👍', account: remote_account)
+
+      reaction = status.reactions.build(name: '😘', account: remote_account)
+      subject.validate(reaction)
+      expect(reaction.errors).to be_empty
+    end
+  end
+end

--- a/spec/workers/unreact_worker_spec.rb
+++ b/spec/workers/unreact_worker_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe UnreactWorker do
+  let(:worker) { described_class.new }
+
+  describe 'perform' do
+    it 'runs without error for missing record' do
+      account_id = nil
+      status_id = nil
+      emoji = nil
+      expect { worker.perform(account_id, status_id, emoji) }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
I apparently hit a limit for workflows (or they were broken), so I couldn't run the full test suite on these, but the ones which didn't refuse to start all succeeded and I tested them locally.

Feel free to squash