### PR TITLE
Fix most backend issues

### DIFF
--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -182,21 +182,17 @@ class ActivityPub::Activity
   # Ensure emoji declared in the activity's tags are
   # present in the database and downloaded to the local cache.
   # Required by EmojiReact and Like for emoji reactions.
-  def process_emoji_tags(tags)
-    emoji_tag = as_array(tags).find { |tag| tag['type'] == 'Emoji' }
-    return if emoji_tag.nil?
+  def process_emoji_tags(name, tags)
+    tag = as_array(tags).find { |item| item['type'] == 'Emoji' }
+    return if tag.nil?
 
-    process_single_emoji emoji_tag
-  end
-
-  def process_single_emoji(tag)
     custom_emoji_parser = ActivityPub::Parser::CustomEmojiParser.new(tag)
-    return if custom_emoji_parser.shortcode.blank? || custom_emoji_parser.image_remote_url.blank?
+    return if custom_emoji_parser.shortcode.blank? || custom_emoji_parser.image_remote_url.blank? || !name.eql?(custom_emoji_parser.shortcode)
 
     emoji = CustomEmoji.find_by(shortcode: custom_emoji_parser.shortcode, domain: @account.domain)
-    return unless emoji.nil? ||
-                  custom_emoji_parser.image_remote_url != emoji.image_remote_url ||
-                  (custom_emoji_parser.updated_at && custom_emoji_parser.updated_at >= emoji.updated_at)
+    return emoji unless emoji.nil? ||
+                        custom_emoji_parser.image_remote_url != emoji.image_remote_url ||
+                        (custom_emoji_parser.updated_at && custom_emoji_parser.updated_at >= emoji.updated_at)
 
     begin
       emoji ||= CustomEmoji.new(domain: @account.domain,
@@ -206,6 +202,8 @@ class ActivityPub::Activity
       emoji.save
     rescue Seahorse::Client::NetworkingError => e
       Rails.logger.warn "Error fetching emoji: #{e}"
+      return
     end
+    emoji
   end
 end

--- a/app/lib/activitypub/activity.rb
+++ b/app/lib/activitypub/activity.rb
@@ -179,13 +179,14 @@ class ActivityPub::Activity
     nil
   end
 
-  # Ensure all emojis declared in the activity's tags are
+  # Ensure emoji declared in the activity's tags are
   # present in the database and downloaded to the local cache.
   # Required by EmojiReact and Like for emoji reactions.
   def process_emoji_tags(tags)
-    as_array(tags).each do |tag|
-      process_single_emoji tag if tag['type'] == 'Emoji'
-    end
+    emoji_tag = as_array(tags).find { |tag| tag['type'] == 'Emoji' }
+    return if emoji_tag.nil?
+
+    process_single_emoji emoji_tag
   end
 
   def process_single_emoji(tag)

--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -22,5 +22,7 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
     reaction = original_status.status_reactions.create!(account: @account, name: name, custom_emoji: custom_emoji)
 
     LocalNotificationWorker.perform_async(original_status.account_id, reaction.id, 'StatusReaction', 'reaction')
+  rescue ActiveRecord::RecordInvalid
+    nil
   end
 end

--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -6,8 +6,7 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
     name = @json['content']
     return if original_status.nil? ||
               !original_status.account.local? ||
-              delete_arrived_first?(@json['id']) ||
-              @account.reacted?(original_status, name)
+              delete_arrived_first?(@json['id'])
 
     custom_emoji = nil
     if /^:.*:$/.match?(name)
@@ -17,6 +16,8 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
       custom_emoji = CustomEmoji.find_by(shortcode: name, domain: @account.domain)
       return if custom_emoji.nil?
     end
+
+    return if @account.reacted?(original_status, name, custom_emoji)
 
     reaction = original_status.status_reactions.create!(account: @account, name: name, custom_emoji: custom_emoji)
 

--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -8,12 +8,10 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
               !original_status.account.local? ||
               delete_arrived_first?(@json['id'])
 
-    custom_emoji = nil
     if /^:.*:$/.match?(name)
-      process_emoji_tags(@json['tag'])
-
       name.delete! ':'
-      custom_emoji = CustomEmoji.find_by(shortcode: name, domain: @account.domain)
+      custom_emoji = process_emoji_tags(@json['tag'])
+
       return if custom_emoji.nil?
     end
 

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -5,7 +5,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
     original_status = status_from_uri(object_uri)
     return if original_status.nil? || !original_status.account.local? || delete_arrived_first?(@json['id'])
 
-    return if maybe_process_misskey_reaction(original_status)
+    return if maybe_process_misskey_reaction
 
     return if @account.favourited?(original_status)
 
@@ -17,16 +17,15 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
   # Misskey delivers reactions as likes with the emoji in _misskey_reaction
   # see https://misskey-hub.net/ns.html#misskey-reaction for details
-  def maybe_process_misskey_reaction(original_status)
+  def maybe_process_misskey_reaction
+    original_status = status_from_uri(object_uri)
     name = @json['_misskey_reaction']
     return false if name.nil?
 
-    custom_emoji = nil
     if /^:.*:$/.match?(name)
-      process_emoji_tags(@json['tag'])
-
       name.delete! ':'
-      custom_emoji = CustomEmoji.find_by(shortcode: name, domain: @account.domain)
+      custom_emoji = process_emoji_tags(@json['tag'])
+
       return false if custom_emoji.nil? # invalid custom emoji, treat it as a regular like
     end
     return true if @account.reacted?(original_status, name, custom_emoji)

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -29,7 +29,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
       custom_emoji = CustomEmoji.find_by(shortcode: name, domain: @account.domain)
       return false if custom_emoji.nil? # invalid custom emoji, treat it as a regular like
     end
-    return true if @account.reacted?(original_status, name)
+    return true if @account.reacted?(original_status, name, custom_emoji)
 
     reaction = original_status.status_reactions.create!(account: @account, name: name, custom_emoji: custom_emoji)
     LocalNotificationWorker.perform_async(original_status.account_id, reaction.id, 'StatusReaction', 'reaction')

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -34,5 +34,8 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
     reaction = original_status.status_reactions.create!(account: @account, name: name, custom_emoji: custom_emoji)
     LocalNotificationWorker.perform_async(original_status.account_id, reaction.id, 'StatusReaction', 'reaction')
     true
+  # account tried to react with disabled custom emoji. Returning true to discard activity.
+  rescue ActiveRecord::RecordInvalid
+    true
   end
 end

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -117,13 +117,25 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
 
   def undo_emoji_react
     name = @object['content']
+    tags = @object['tag']
     return if name.nil?
 
     status = status_from_uri(target_uri)
+    name.delete! ':'
 
     return if status.nil? || !status.account.local?
 
-    if @account.reacted?(status, name.delete(':'))
+    custom_emoji = nil
+    emoji_tag = as_array(tags).find { |tag| tag['type'] == 'Emoji' }
+
+    if emoji_tag
+      custom_emoji_parser = ActivityPub::Parser::CustomEmojiParser.new(emoji_tag)
+      return if custom_emoji_parser.shortcode.blank? || custom_emoji_parser.image_remote_url.blank?
+
+      custom_emoji = CustomEmoji.find_by(shortcode: custom_emoji_parser.shortcode, domain: @account.domain)
+    end
+
+    if @account.reacted?(status, name, custom_emoji)
       reaction = status.status_reactions.where(account: @account, name: name).first
       reaction&.destroy
     else

--- a/app/lib/activitypub/activity/undo.rb
+++ b/app/lib/activitypub/activity/undo.rb
@@ -110,13 +110,15 @@ class ActivityPub::Activity::Undo < ActivityPub::Activity
     if @account.favourited?(status)
       favourite = status.favourites.where(account: @account).first
       favourite&.destroy
+    elsif @object['_misskey_reaction'].present?
+      undo_emoji_react
     else
       delete_later!(object_uri)
     end
   end
 
   def undo_emoji_react
-    name = @object['content']
+    name = @object['content'] || @object['_misskey_reaction']
     tags = @object['tag']
     return if name.nil?
 

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -243,8 +243,8 @@ module AccountInteractions
     status.proper.favourites.where(account: self).exists?
   end
 
-  def reacted?(status, name)
-    status.proper.status_reactions.where(account: self, name: name).exists?
+  def reacted?(status, name, custom_emoji = nil)
+    status.proper.status_reactions.where(account: self, name: name, custom_emoji: custom_emoji).exists?
   end
 
   def bookmarked?(status)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -300,7 +300,7 @@ class Status < ApplicationRecord
       if account.nil?
         scope.select('name, custom_emoji_id, count(*) as count, false as me')
       else
-        scope.select("name, custom_emoji_id, count(*) as count, exists(select 1 from status_reactions r where r.account_id = #{account.id} and r.status_id = status_reactions.status_id and r.name = status_reactions.name) as me")
+        scope.select("name, custom_emoji_id, count(*) as count, exists(select 1 from status_reactions r where r.account_id = #{account.id} and r.status_id = status_reactions.status_id and r.name = status_reactions.name and (r.custom_emoji_id = status_reactions.custom_emoji_id or r.custom_emoji_id is null and status_reactions.custom_emoji_id is null)) as me")
       end
     end
 

--- a/app/models/status_reaction.rb
+++ b/app/models/status_reaction.rb
@@ -26,7 +26,8 @@ class StatusReaction < ApplicationRecord
 
   private
 
+  # Sets custom_emoji to nil when disabled
   def set_custom_emoji
-    self.custom_emoji = CustomEmoji.find_by(shortcode: name, domain: account.domain) if name.blank?
+    self.custom_emoji = CustomEmoji.find_by(disabled: false, shortcode: name, domain: custom_emoji.domain) if name.present? && custom_emoji.present?
   end
 end

--- a/app/services/react_service.rb
+++ b/app/services/react_service.rb
@@ -8,6 +8,8 @@ class ReactService < BaseService
     authorize_with account, status, :react?
 
     name, domain = emoji.split('@')
+    return unless domain.nil? || status.local?
+
     custom_emoji = CustomEmoji.find_by(shortcode: name, domain: domain)
     reaction = StatusReaction.find_by(account: account, status: status, name: name, custom_emoji: custom_emoji)
     return reaction unless reaction.nil?

--- a/app/validators/status_reaction_validator.rb
+++ b/app/validators/status_reaction_validator.rb
@@ -19,7 +19,7 @@ class StatusReactionValidator < ActiveModel::Validator
   end
 
   def new_reaction?(reaction)
-    !reaction.status.status_reactions.exists?(status: reaction.status, account: reaction.account, name: reaction.name)
+    !reaction.status.status_reactions.exists?(status: reaction.status, account: reaction.account, name: reaction.name, custom_emoji: reaction.custom_emoji)
   end
 
   def limit_reached?(reaction)


### PR DESCRIPTION
Fixes multiple occurrences of looking for `:shortcode:` in the database, preventing `Undo` activities to be processed.
Added handling for `Undo` with Misskey reactions.
Fixes an issue where `me` was true when a remote reaction had the same shortcode as an already present reaction.
Added `custom_emoji` to `reacted?` to be able to differentiate between reactions with the same shortcode but different emojis.

Don't know if you were already working on this or not, but I thought I offer my solution.
Some of it could probably be optimised, but I worked multiple days on this and I'm tired.

Outstanding issues:
Because reactions from the same account with the same name, but different custom emojis can exist, it is possible for sidekiq to throw:
```
ActiveRecord::RecordNotUnique: PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_status_reactions_on_account_id_and_status_id"
```
for remote reactions and `Duplicate record` for local reactions.