### PR TITLE
Add missing `name` param.

### DIFF
--- a/app/lib/activitypub/activity/emoji_react.rb
+++ b/app/lib/activitypub/activity/emoji_react.rb
@@ -10,7 +10,7 @@ class ActivityPub::Activity::EmojiReact < ActivityPub::Activity
 
     if /^:.*:$/.match?(name)
       name.delete! ':'
-      custom_emoji = process_emoji_tags(@json['tag'])
+      custom_emoji = process_emoji_tags(name, @json['tag'])
 
       return if custom_emoji.nil?
     end

--- a/app/lib/activitypub/activity/like.rb
+++ b/app/lib/activitypub/activity/like.rb
@@ -24,7 +24,7 @@ class ActivityPub::Activity::Like < ActivityPub::Activity
 
     if /^:.*:$/.match?(name)
       name.delete! ':'
-      custom_emoji = process_emoji_tags(@json['tag'])
+      custom_emoji = process_emoji_tags(name, @json['tag'])
 
       return false if custom_emoji.nil? # invalid custom emoji, treat it as a regular like
     end


### PR DESCRIPTION
Follow-up to #4
Missed these while porting changes.